### PR TITLE
Only send notifications when release are published

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const sendEmail = require('./src/sendMail')
 module.exports = app => {
 	app.log('Yay, the app was loaded!')
 
-	app.on('release', async context => {
+	app.on('release.published', async context => {
 		app.log("Yayyy we released. Now let's do some stuff!")
 
 		const configPath = 'releaseBuddy.config.json'


### PR DESCRIPTION
Previously, it would send notifications for all events related to `releases`. It should only send when a release has been published and not when it created, edited or deleted. 