### PR TITLE
updated nodejs engine to v10

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -6,7 +6,7 @@ package:
 
 provider:
   name: google
-  runtime: nodejs8
+  runtime: nodejs10
   project: ${env:GCP_PROJECT}
   credentials: ${env:GCP_CREDENTIALS}
 


### PR DESCRIPTION
Google has sent out a notice informing GCP users that they are shutting down support for node v8  soon, and that **new** deployments using v8 as the engine will not be accepted after this coming September. This PR updates the serverless config to use node engine v10.

## Notes
There is no need to re-deploy the lambdas yet per-se; *existing* deployments will continue to operate. It's only **new** deployments that must be set to v10. By changing the config file here, we ensure that our next deployment will be up-to-date.